### PR TITLE
Add MacOS surface support to graphics example

### DIFF
--- a/examples/compute/src/main.rs
+++ b/examples/compute/src/main.rs
@@ -17,6 +17,8 @@ fn get_memory_type_index(
 
 #[allow(clippy::float_cmp)]
 pub fn main() {
+    let is_debug = false;
+
     // load the Vulkan lib
     let globals = Globals::new().unwrap();
 
@@ -28,7 +30,26 @@ pub fn main() {
         let app_info = vk::ApplicationInfo::builder()
             .p_application_name(Some(c"compute"))
             .api_version(version);
-        let instance_create_info = vk::InstanceCreateInfo::builder().p_application_info(Some(&app_info));
+        
+        let mut extensions = spark::InstanceExtensions::new(version);
+
+        if is_debug {
+            extensions.enable_ext_debug_utils();
+        }
+
+        #[cfg(target_os = "macos")]
+        extensions.enable_khr_portability_enumeration();
+
+        let extension_names = extensions.to_name_vec();
+        let extension_name_ptrs: Vec<_> = extension_names.iter().map(|s| s.as_ptr()).collect();
+
+        let instance_create_info = vk::InstanceCreateInfo::builder()
+            .p_application_info(Some(&app_info))
+            .pp_enabled_extension_names(&extension_name_ptrs);
+
+        #[cfg(target_os = "macos")]
+        let instance_create_info = instance_create_info.flags(vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR);
+
         unsafe { globals.create_instance_commands(&instance_create_info, None) }.unwrap()
     };
 

--- a/examples/graphics/Cargo.toml
+++ b/examples/graphics/Cargo.toml
@@ -13,3 +13,6 @@ egui = "0.23"
 egui-winit = "0.23"
 raw-window-handle = "0.5"
 bytemuck = "1.14.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+raw-window-metal = "1.1.0"

--- a/examples/graphics/src/context.rs
+++ b/examples/graphics/src/context.rs
@@ -76,6 +76,10 @@ impl Context {
             if is_debug {
                 extensions.enable_ext_debug_utils();
             }
+
+            #[cfg(target_os = "macos")]
+            extensions.enable_khr_portability_enumeration();
+
             let extension_names = extensions.to_name_vec();
 
             let app_info = vk::ApplicationInfo::builder()
@@ -86,6 +90,10 @@ impl Context {
             let instance_create_info = vk::InstanceCreateInfo::builder()
                 .p_application_info(Some(&app_info))
                 .pp_enabled_extension_names(&extension_name_ptrs);
+
+            #[cfg(target_os = "macos")]
+            let instance_create_info = instance_create_info.flags(vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR);
+
             unsafe { globals.create_instance_commands(&instance_create_info, None) }.unwrap()
         };
 

--- a/spark/src/lib.rs
+++ b/spark/src/lib.rs
@@ -55,6 +55,9 @@ const DL_PATH: &str = "vulkan-1.dll";
 #[cfg(target_os = "android")]
 const DL_PATH: &str = "libvulkan.so";
 
+#[cfg(target_os = "macos")]
+const DL_PATH: &str = "libvulkan.1.dylib";
+
 impl Lib {
     pub fn new() -> LoadResult<Self> {
         match DynamicLibrary::open(Some(Path::new(&DL_PATH))) {


### PR DESCRIPTION
Adds the required extension and surface to get the graphics example running on Mac OS, added behind config attributes.